### PR TITLE
ホームページのスタイルを調整し、メインセクションの最小高さとマージンを変更

### DIFF
--- a/front/css/home.css
+++ b/front/css/home.css
@@ -14,8 +14,8 @@ body {
     background: #fff;
     border-radius: 18px;
     box-shadow: 0 4px 24px rgba(0,0,0,0.08);
-    min-height: 60vh;
-    margin-top: 48px;
+    min-height: 40vh; /* 60vh→40vhに変更 */
+    margin-top: 16px; /* 48px→16pxに変更 */
 }
 
 h1 {


### PR DESCRIPTION
ウィンドウサイズを100%にしたときにホーム画面が見切れるところがあったので解消した。